### PR TITLE
Add support for sitemap indexes (fixes hashobject/sitemap#3)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sitemap "0.2.5"
+(defproject sitemap "0.3.0"
   :description "Clojure library for sitemap generation."
   :signing {:gpg-key "Hashobject Ltd <team@hashobject.com>"}
   :url "https://github.com/hashobject/sitemap"

--- a/src/sitemap/core.clj
+++ b/src/sitemap/core.clj
@@ -1,54 +1,122 @@
 (ns sitemap.core
   "Library for sitemap generation and validation."
-  (:use
-      [clojure.java.io]
-      [hiccup.core :only (html)]
-      [hiccup.page :only (xml-declaration)])
-  (:require [sitemap.validator :as v]))
+  (:require
+    [clojure.java.io :as io]
+    [hiccup.core :refer [html]]
+    [hiccup.page :refer [xml-declaration]]
+    [sitemap.validator :as v]))
 
 ; Sitemaps MUST be UTF-8 encoded - http://www.sitemaps.org/faq.html#faq_output_encoding
 (def encoding-utf-8 "UTF-8")
 
-(defn- xml-header []
-  (html (xml-declaration encoding-utf-8)))
+(def chunk-size 50000)
+
+(def ^:dynamic *extension* ".xml")
+
+(def ^:private xml-header
+  (delay
+    (html (xml-declaration encoding-utf-8))))
+
+
+(defn- spit-utf8 [path s]
+  (spit path s :encoding encoding-utf-8))
 
 
 (defn- generate-url-entry [entry]
   [:url
-    [:loc (:loc entry)]
-    (if (:lastmod entry)
-      [:lastmod (:lastmod entry)])
-    (if (:changefreq entry)
-      [:changefreq (:changefreq entry)])
-    (if (:priority entry)
-      [:priority (:priority entry)])])
+   [:loc (:loc entry)]
+   (when-let [x (:lastmod entry)]
+     [:lastmod x])
+   (when-let [x (:changefreq entry)]
+     [:changefreq x])
+   (when-let [x (:priority entry)]
+     [:priority x])])
 
 
 (defn- generate-url-entries [entries]
   (html
-     [:urlset {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
-      (map generate-url-entry entries)]))
+    [:urlset {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
+     (map generate-url-entry entries)]))
 
 
 (defn generate-sitemap
   "Render Clojure data structures to a String of sitemap XML."
   [url-entries]
-  (str (xml-header)
+  (str @xml-header
        (generate-url-entries url-entries)))
 
 
+(defn generate-sitemap*
+  "Render Clojure data structures to a seq of sitemap XMLs, chunked at the maximum sitemap
+  size (50,000)."
+  [url-entries]
+  (->> url-entries
+       (partition-all chunk-size)
+       (map generate-sitemap)))
+
+
+(defprotocol SitemapPathGenerator
+  (root-path  [_ basename] "Returns the output path for a sitemap or sitemap index.")
+  (chunk-path [_ basename i] "Returns the output path for a sitemap 'chunk' (a sub-sitemap of a sitemap index) with index i."))
+
+(def path-generator
+  "Default output path generator"
+  (reify SitemapPathGenerator
+    (root-path [_ basename]
+      (str basename *extension*))
+    (chunk-path [_ basename i]
+      (str basename "-" i *extension*))))
+
+
+(defn generate-sitemap-index
+  "Generates sitemap index XML for the `sitemap-paths`, returned as a string."
+  [sitemap-paths]
+  (str @xml-header
+       (html
+         [:sitemapindex {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
+          (map (fn [path]
+                 [:sitemap
+                  [:loc path]])
+               sitemap-paths)])))
+
+
+(defn generate-sitemap-and-save*
+  "Render Clojure data structures to sitemap XML, emitting a sitemap index with sitemap chunks
+  when the number of url-entries is greater than permitted for a single sitemap (50,000). The
+  output file name(s) will be based on the basename.
+  
+  Example: (generate-sitemap-and-save* \"https://example.com\" \"dir/sitemap\" url-entries)
+  will emit dir/sitemap.xml when count(url-entries) <= 50,000, otherwise will emit
+  dir/sitemap.xml (index, pointing to https://example.com/sitemap-0.xml and so on),
+  dir/sitemap-0.xml, dir/sitemap-1.xml, and so on."
+  ([absolute-root basename url-entries]
+   (generate-sitemap-and-save* absolute-root basename url-entries path-generator))
+  ([absolute-root basename url-entries path-generator]
+   (let [sitemap-xmls (generate-sitemap* url-entries)
+         root-path (root-path path-generator basename)]
+
+     (if (= 1 (count sitemap-xmls))
+       (spit-utf8 root-path (first sitemap-xmls))
+
+       (let [sitemap-paths (map #(chunk-path path-generator basename %) (range (count sitemap-xmls)))
+             remote-paths (map #(str absolute-root "/" (.getName (io/file %))) sitemap-paths)]
+         (spit-utf8 root-path (generate-sitemap-index remote-paths))
+         (doseq [[xml path] (map vector sitemap-xmls sitemap-paths)]
+           (spit-utf8 path xml)))))))
+
+
 (defn generate-sitemap-and-save
-  "Render Clojure data structures to a string of sitemap XML and save it to file."
+  "Render Clojure data structures to a string of sitemap XML and save it to file. Does not
+  check whether the number of url-entries is greater than allowed."
   [path url-entries]
   (let [sitemap-xml (generate-sitemap url-entries)]
-    (spit path sitemap-xml :encoding encoding-utf-8)
+    (spit-utf8 path sitemap-xml)
     sitemap-xml))
 
 
 (defn save-sitemap [f sitemap-xml]
   "Save the sitemap XML to a UTF-8 encoded File."
-  (doto f
-    (spit sitemap-xml :encoding encoding-utf-8)))
+  (spit-utf8 f sitemap-xml))
 
 
 (defn validate-sitemap [in]


### PR DESCRIPTION
This adds support for "sitemap index files", which are used when # of links > 50,000.

The current `(generate-sitemap url-entries)` is not changed. Instead, this PR adds `(generate-sitemap-and-save* absolute-root basename url-entries)` which is aware of the 50k limit and will emit chunked entries if necessary. I'm not sure this is the ideal solution, but it's backwards-compatible.

We've been using this in prod for a few months now and haven't seen any issues, but all comments are welcome.

Cheers,
-Ben